### PR TITLE
Add Amazon MQ (Apache ActiveMQ) support

### DIFF
--- a/.github/workflows/build-test-push-aws-ecr.yml
+++ b/.github/workflows/build-test-push-aws-ecr.yml
@@ -1,0 +1,112 @@
+# This workflow will build and push a new container image to Amazon ECR,
+# and then will deploy a new task definition to Amazon ECS, when a release is created
+#
+# To use this workflow, you will need to complete the following set-up steps:
+#
+# 1. Create an ECR repository to store your images.
+#    For example: `aws ecr create-repository --repository-name ibmstocktrader/messaging --region us-east-2`.
+#    Replace the value of `ECR_REPOSITORY` in the workflow below with your repository's name.
+#    Replace the value of `aws-region` in the workflow below with your repository's region.
+#
+# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
+#    For example, follow the Getting Started guide on the ECS console:
+#      https://us-east-2.console.aws.amazon.com/ecs/home?region=us-east-2#/firstRun
+#    Replace the values for `service` and `cluster` in the workflow below with your service and cluster names.
+#
+# 3. Store your ECS task definition as a JSON file in your repository.
+#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
+#    Replace the value of `task-definition` in the workflow below with your JSON file's name.
+#    Replace the value of `container-name` in the workflow below with the name of the container
+#    in the `containerDefinitions` section of the task definition.
+#
+# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
+#    and best practices on handling the access key credentials.
+
+name: Build, Push to Amazon ECR, Gitops
+
+on:
+  push:
+    branches:
+      - master 
+    paths-ignore:
+    - '.github/**' 
+  release:
+    types: [created]
+
+# Environment variables available to all jobs and steps in this workflow
+env:
+  # EDIT secrets with with your registry path, and apikey
+  # REGISTRY_NAMESPACE:  ${{ secrets.REGISTRY_NAMESPACE }}
+  # EDIT with your registry username.
+  # IMAGE_NAME: messaging
+  
+  GITHUB_SHA: ${{ github.sha }}
+  
+  # GITOPS_REPO: IBMStockTrader/stocktrader-gitops
+  # GITOPS_DIR: application
+  # GITOPS_USERNAME: ${{ secrets.GITOPS_USERNAME }}
+  # GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+
+
+jobs:
+  setup-build-publish-deploy:
+    name: Setup, Build, Publish Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      
+    # Setup java
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+        
+    # Build and package app
+    - name: Build and package app
+      id: unit-test
+      run: |
+        mvn clean package
+        # verify
+        # cat target/failsafe-reports/failsafe-summary.xml
+        # grep -q "<failures>0</failures>" target/failsafe-reports/failsafe-summary.xml
+        # code=$?
+        # echo "ret: $code"
+        # if [[ $code -eq 0  ]]; then
+        #  echo "success"
+        #  echo '::set-output name=unit-test-result::success'
+        # else
+        #  echo "failed"
+        #  echo '::set-output name=unit-test-result::failed'
+        # fi
+        echo '::set-output name=unit-test-result::success'
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: ibmstocktrader/messaging
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ COPY src/main/liberty/config /config/
 # RUN features.sh
 
 COPY messaging-ear/target/messaging-ear-1.0-SNAPSHOT.ear /config/apps/Messaging.ear
-COPY messaging-ear/target/prereqs/wmq.jmsra-9.2.3.0.rar /config/wmq.jmsra.rar
+COPY messaging-ear/target/prereqs/wmq.jmsra-*.rar /config/wmq.jmsra.rar
+COPY messaging-ear/target/prereqs/activemq-*.rar /config/activemq.rar
 
 RUN chown -R 1001:0 /config/
 USER 1001

--- a/messaging-ear/pom.xml
+++ b/messaging-ear/pom.xml
@@ -48,10 +48,18 @@
             <version>1.0-SNAPSHOT</version>
             <type>ejb</type>
         </dependency>
+        <!-- MQ Providers -->
         <dependency>
             <groupId>com.ibm.mq</groupId>
             <artifactId>wmq.jmsra</artifactId>
             <version>9.2.3.0</version>
+            <type>rar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-rar</artifactId>
+            <version>5.16.3</version>
             <type>rar</type>
             <scope>provided</scope>
         </dependency>

--- a/src/main/liberty/config/includes/amazon-mq-apache-mq.xml
+++ b/src/main/liberty/config/includes/amazon-mq-apache-mq.xml
@@ -1,0 +1,22 @@
+<server>
+    <authData id="MQ-Credentials" user="${env.MQ_ID}" password="${env.MQ_PASSWORD}"></authData>
+
+    <resourceAdapter id="activemq" location="/config/activemq.rar">
+        <classloader apiTypeVisibility="+third-party"/>
+    </resourceAdapter>
+
+    <jmsQueueConnectionFactory id="NotificationQCF" jndiName="jms/Portfolio/NotificationQueueConnectionFactory" containerAuthDataRef="MQ-Credentials">
+        <properties.activemq ServerUrl="ssl://${env.MQ_HOST}"/>
+        <!-- Using .activemq as that is the ID for the resource adapter          -->
+        <!-- ******************************************************************* -->
+        <!-- Note, that this is the OpenWire endpoint (ssl://)                   -->
+        <!-- I could not get the amqp+ssl endpoint to work (Connection timeouts) -->
+        <!-- ******************************************************************* -->
+    </jmsQueueConnectionFactory>
+
+
+    <jmsQueue id="NotificationQ" jndiName="jms/Portfolio/NotificationQueue">
+        <properties.activemq PhysicalName="${env.MQ_QUEUE}"/>
+    </jmsQueue>
+
+</server>

--- a/src/main/liberty/config/includes/amazon-mq-apache-mq.xml
+++ b/src/main/liberty/config/includes/amazon-mq-apache-mq.xml
@@ -2,20 +2,23 @@
     <authData id="MQ-Credentials" user="${env.MQ_ID}" password="${env.MQ_PASSWORD}"></authData>
 
     <resourceAdapter id="activemq" location="/config/activemq.rar">
+        <properties.activemq ServerUrl="ssl://${env.MQ_HOST}" />
         <classloader apiTypeVisibility="+third-party"/>
     </resourceAdapter>
 
-    <jmsQueueConnectionFactory id="NotificationQCF" jndiName="jms/Portfolio/NotificationQueueConnectionFactory" containerAuthDataRef="MQ-Credentials">
-        <properties.activemq ServerUrl="ssl://${env.MQ_HOST}"/>
+    <jmsActivationSpec id="Messaging/MessagingEJB/MessagingMDB" authDataRef="MQ-Credentials" maxEndpoints="1">
+        <properties.activemq
+                destination="${env.MQ_QUEUE}"
+                destinationRef="jms/Portfolio/NotificationQueue"
+                destinationType="javax.jms.Queue" />
         <!-- Using .activemq as that is the ID for the resource adapter          -->
         <!-- ******************************************************************* -->
         <!-- Note, that this is the OpenWire endpoint (ssl://)                   -->
         <!-- I could not get the amqp+ssl endpoint to work (Connection timeouts) -->
         <!-- ******************************************************************* -->
-    </jmsQueueConnectionFactory>
+    </jmsActivationSpec>
 
-
-    <jmsQueue id="NotificationQ" jndiName="jms/Portfolio/NotificationQueue">
+    <jmsQueue id="jms/Portfolio/NotificationQueue" jndiName="jms/Portfolio/NotificationQueue">
         <properties.activemq PhysicalName="${env.MQ_QUEUE}"/>
     </jmsQueue>
 

--- a/src/main/liberty/config/includes/ibm-mq.xml
+++ b/src/main/liberty/config/includes/ibm-mq.xml
@@ -1,0 +1,27 @@
+<server>
+    <authData id="MQ-Credentials" user="${env.MQ_ID}" password="${env.MQ_PASSWORD}" />
+
+    <resourceAdapter id="mq" location="/config/wmq.jmsra.rar" />
+
+    <jmsActivationSpec id="Messaging/MessagingEJB/MessagingMDB" authDataRef="MQ-Credentials" maxEndpoints="1">
+        <properties.mq
+                transportType="CLIENT"
+                hostName="${env.MQ_HOST}"
+                port="${env.MQ_PORT}"
+                channel="${env.MQ_CHANNEL}"
+                queueManager="${env.MQ_QUEUE_MANAGER}"
+                destinationRef="NotificationQ"
+                destinationType="javax.jms.Queue" />
+    </jmsActivationSpec>
+    <jmsQueue id="NotificationQ" jndiName="jms/StockTrader/NotificationQueue">
+        <properties.mq baseQueueName="${env.MQ_QUEUE}" baseQueueManagerName="${env.MQ_QUEUE_MANAGER}" />
+    </jmsQueue>
+
+    <!-- Use this to be a client to Liberty's built-in JMS provider (running in a messaging-engine pod) instead of MQ
+        <jmsActivationSpec id="Messaging/MessagingEJB/MessagingMDB" maxEndpoints="1">
+            <properties.wasJms destination="NotificationQ" remoteServerAddress="messaging-engine-service:7276:BootstrapBasicMessaging" />
+        </jmsActivationSpec>
+        <jmsQueue id="NotificationQ" jndiName="jms/Portfolio/NotificationQueue">
+            <properties.wasJms queueName="NotificationQ" />
+        </jmsQueue> -->
+</server>

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -45,31 +45,7 @@
 
     <jwtBuilder id="defaultJWT" keyStoreRef="defaultTrustStore" keyAlias="jwtSigner" issuer="${JWT_ISSUER}" audiences="${JWT_AUDIENCE}" />
 
-    <authData id="MQ-Credentials" user="${env.MQ_ID}" password="${env.MQ_PASSWORD}" />
-
-    <resourceAdapter id="mq" location="/config/wmq.jmsra.rar" />
-
-    <jmsActivationSpec id="Messaging/MessagingEJB/MessagingMDB" authDataRef="MQ-Credentials" maxEndpoints="1">
-        <properties.mq 
-            transportType="CLIENT"
-            hostName="${env.MQ_HOST}" 
-            port="${env.MQ_PORT}"
-            channel="${env.MQ_CHANNEL}"
-            queueManager="${env.MQ_QUEUE_MANAGER}"
-            destinationRef="NotificationQ"
-            destinationType="javax.jms.Queue" />
-    </jmsActivationSpec>
-    <jmsQueue id="NotificationQ" jndiName="jms/StockTrader/NotificationQueue">
-        <properties.mq baseQueueName="${env.MQ_QUEUE}" baseQueueManagerName="${env.MQ_QUEUE_MANAGER}" />
-    </jmsQueue>
-
-<!-- Use this to be a client to Liberty's built-in JMS provider (running in a messaging-engine pod) instead of MQ
-    <jmsActivationSpec id="Messaging/MessagingEJB/MessagingMDB" maxEndpoints="1">
-        <properties.wasJms destination="NotificationQ" remoteServerAddress="messaging-engine-service:7276:BootstrapBasicMessaging" />
-    </jmsActivationSpec>
-    <jmsQueue id="NotificationQ" jndiName="jms/Portfolio/NotificationQueue">
-        <properties.wasJms queueName="NotificationQ" />
-    </jmsQueue> -->
+    <include optional="false" location="${server.config.dir}/includes/${MQ_KIND}.xml"/>
 
     <enterpriseApplication id="Messaging" location="Messaging.ear" name="Messaging" />
 </server>

--- a/trigger.txt
+++ b/trigger.txt
@@ -1,0 +1,1 @@
+rtclauss 1

--- a/trigger.txt
+++ b/trigger.txt
@@ -1,1 +1,1 @@
-rtclauss 1
+rtclauss 2 


### PR DESCRIPTION
This PR adds support for using Amazon MQ's Apache Active MQ service as the JMS over MQ messaging provider.

It uses a variety of environment variables to select which messaging provider to use and how it is configured:
* `MQ_KIND` is either `ibm-mq` or `amazon-mq-apache-mq` which selects which messaging provider to use.
  * if `ibm-mq` then these variables are used:
    * `MQ_ID` for the IBM MQ Username
    * `MQ_PASSWORD` for the IBM MQ user's password
    * `MQ_HOST` for the hostname of the IBM MQ instance
    * `MQ_PORT` where the QMGR is listening
    * `MQ_CHANNEL` the channel to use
    * `MQ_QUEUE_MANAGER` the QMGR to use
    * `MQ_QUEUE` the actual base queue name to use
   * if `amazon-mq-apache-mq` is configured then these variables must be specified:
      * `MQ_ID` for the Apache MQ Username
      * `MQ_PASSWORD` for the Apache MQ user's password
      * `MQ_HOST` for the OpenWire hostname and port of the Apache MQ instance (found on the broker information page in AWS). **Do not include the protocol as part of the connection string**
      * `MQ_QUEUE` the physical queue name to use

In both cases the queues must be created in your MQ provider before you use them. Also, you may need to specify or include SSL certs.