### PR TITLE
Add support for Active MQ Failover URLs

### DIFF
--- a/chart/messaging/templates/deployment.yaml
+++ b/chart/messaging/templates/deployment.yaml
@@ -50,6 +50,11 @@ spec:
               secretKeyRef:
                 name: mq   
                 key: pwd
+          - name: MQ_URL
+            valueFrom:
+              secretKeyRef:
+                name: mq
+                key: url
           - name: MQ_HOST
             valueFrom:
               secretKeyRef:

--- a/manifests/demodeploy.yaml
+++ b/manifests/demodeploy.yaml
@@ -49,6 +49,11 @@ spec:
               secretKeyRef:
                 name: mq   
                 key: pwd
+          - name: MQ_URL
+            valueFrom:
+              secretKeyRef:
+                name: mq
+                key: url
           - name: MQ_HOST
             valueFrom:
               secretKeyRef:

--- a/manifests/deploy.yaml
+++ b/manifests/deploy.yaml
@@ -48,6 +48,11 @@ spec:
               secretKeyRef:
                 name: mq   
                 key: pwd
+          - name: MQ_URL
+            valueFrom:
+              secretKeyRef:
+                name: mq
+                key: url
           - name: MQ_HOST
             valueFrom:
               secretKeyRef:

--- a/manifests/messaging-values.yaml
+++ b/manifests/messaging-values.yaml
@@ -34,6 +34,11 @@ image:
         secretKeyRef:
           name: mq   
           key: pwd
+    - name: MQ_URL
+      valueFrom:
+        secretKeyRef:
+          name: mq
+          key: url
     - name: MQ_HOST
       valueFrom:
         secretKeyRef:

--- a/src/main/liberty/config/includes/amazon-mq-apache-mq.xml
+++ b/src/main/liberty/config/includes/amazon-mq-apache-mq.xml
@@ -2,7 +2,7 @@
     <authData id="MQ-Credentials" user="${env.MQ_ID}" password="${env.MQ_PASSWORD}"></authData>
 
     <resourceAdapter id="activemq" location="/config/activemq.rar">
-        <properties.activemq ServerUrl="ssl://${env.MQ_HOST}" />
+        <properties.activemq ServerUrl="${env.MQ_URL}" />
         <classloader apiTypeVisibility="+third-party"/>
     </resourceAdapter>
 

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -32,6 +32,7 @@
 
     <variable name="JWT_AUDIENCE" defaultValue="stock-trader"/>
     <variable name="JWT_ISSUER" defaultValue="http://stock-trader.ibm.com"/>
+    <variable name="MQ_URL" defaultValue="ssl://${MQ_HOST}:${MQ_PORT}"/>
 
     <logging traceSpecification="*=info" consoleLogLevel="INFO" />
 


### PR DESCRIPTION
This PR adds support for Active MQ failover URLs. This allows us to use highly-available brokers.

The parent PR which adds this support to the operator is: https://github.com/IBMStockTrader/stocktrader-operator/pull/9